### PR TITLE
Fix: Polarion lookup method param name is wrong

### DIFF
--- a/pkg/ginkgo-reporters/polarion_reporter.go
+++ b/pkg/ginkgo-reporters/polarion_reporter.go
@@ -99,7 +99,7 @@ func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigT
 				Value: reporter.ProjectId,
 			},
 			{
-				Name:  "polarion-testcase-lookup-method",
+				Name:  "polarion-lookup-method",
 				Value: "name",
 			},
 			{

--- a/pkg/ginkgo-reporters/polarion_reporter_test.go
+++ b/pkg/ginkgo-reporters/polarion_reporter_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ginkgo_reporters", func() {
 					Value: "QE",
 				},
 				{
-					Name:  "polarion-testcase-lookup-method",
+					Name:  "polarion-lookup-method",
 					Value: "name",
 				},
 				{


### PR DESCRIPTION
I was using the wrong param name, which caused the TCs not to be found

