### PR TITLE
Polarion TC importer - added required fields for approval

### DIFF
--- a/pkg/polarion-generator/test_cases_generator.go
+++ b/pkg/polarion-generator/test_cases_generator.go
@@ -177,7 +177,7 @@ func parseIt(testcase *polarion_xml.TestCase, block *ginkgoBlock, funcBody *ast.
 	})
 }
 
-func parseTable(testcases *polarion_xml.TestCases, block *ginkgoBlock, exprs []ast.Expr, customFields *polarion_xml.TestCaseCustomFields) {
+func parseTable(testcases *polarion_xml.TestCases, block *ginkgoBlock, exprs []ast.Expr, customFields *polarion_xml.TestCaseCustomFields, filename string) {
 	lit := exprs[0].(*ast.BasicLit)
 	baseName := strings.Trim(lit.Value, "\"")
 
@@ -219,6 +219,10 @@ func parseTable(testcases *polarion_xml.TestCases, block *ginkgoBlock, exprs []a
 		}
 		addCustomField(&testCase.TestCaseCustomFields, "caseautomation", "automated")
 		addCustomField(&testCase.TestCaseCustomFields, "testtype", "functional")
+		addCustomField(&testCase.TestCaseCustomFields, "subtype1", "-")
+		addCustomField(&testCase.TestCaseCustomFields, "subtype2", "-")
+		addCustomField(&testCase.TestCaseCustomFields, "status-id", "proposed")
+		addCustomField(&testCase.TestCaseCustomFields, "automation_script", filename)
 		addCustomField(&testCase.TestCaseCustomFields, "upstream", "yes")
 		testcases.TestCases = append(testcases.TestCases, *testCase)
 	}
@@ -259,7 +263,7 @@ func isFieldValueSupported(value string, supportedValues []string) bool {
 }
 
 // FillPolarionTestCases parse ginkgo format test and fill polarion test cases struct accordingly
-func FillPolarionTestCases(f *ast.File, testCases *polarion_xml.TestCases, commentMap *ast.CommentMap) error {
+func FillPolarionTestCases(f *ast.File, testCases *polarion_xml.TestCases, commentMap *ast.CommentMap, filename string) error {
 	var block *ginkgoBlock
 
 	ast.Inspect(f, func(n ast.Node) bool {
@@ -329,7 +333,7 @@ func FillPolarionTestCases(f *ast.File, testCases *polarion_xml.TestCases, comme
 			case ginkgoTable:
 				customFields := polarion_xml.TestCaseCustomFields{}
 				parseComments(x, commentMap, &customFields)
-				parseTable(testCases, block, x.Args, &customFields)
+				parseTable(testCases, block, x.Args, &customFields, filename)
 				return false
 			case ginkgoIt, ginkgoSpecify:
 				for i := len(block.rparenPos) - 1; i >= 0; i-- {
@@ -347,6 +351,10 @@ func FillPolarionTestCases(f *ast.File, testCases *polarion_xml.TestCases, comme
 				customFields := polarion_xml.TestCaseCustomFields{}
 				addCustomField(&customFields, "caseautomation", "automated")
 				addCustomField(&customFields, "testtype", "functional")
+				addCustomField(&customFields, "subtype1", "-")
+				addCustomField(&customFields, "subtype2", "-")
+				addCustomField(&customFields, "status-id", "proposed")
+				addCustomField(&customFields, "automation_script", filename)
 				addCustomField(&customFields, "upstream", "yes")
 				testCase := polarion_xml.TestCase{
 					Title:       polarion_xml.Title{Content: title},
@@ -417,7 +425,9 @@ func main() {
 		cmap := ast.NewCommentMap(fset, f, f.Comments)
 
 		// fill polarion test cases struct
-		FillPolarionTestCases(f, testCases, &cmap)
+		pathToFile := strings.Split(file, "/")
+		filenameShort := pathToFile[len(pathToFile)-1]
+		FillPolarionTestCases(f, testCases, &cmap, filenameShort)
 	}
 
 	// generate polarion test cases XML file

--- a/pkg/polarion-generator/test_cases_generator_test.go
+++ b/pkg/polarion-generator/test_cases_generator_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Test Case Generator", func() {
 		cmap := ast.NewCommentMap(fset, f, f.Comments)
 
 		testCases = &polarion_xml.TestCases{}
-		FillPolarionTestCases(f, testCases, &cmap)
+		FillPolarionTestCases(f, testCases, &cmap, "")
 
 		Expect(len(testCases.TestCases)).To(Equal(4))
 	})
@@ -239,6 +239,10 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "medium", ID: "caseimportance"},
 					{Content: "automated", ID: "caseautomation"},
 					{Content: "functional", ID: "testtype"},
+					{Content: "-", ID: "subtype1"},
+					{Content: "-", ID: "subtype2"},
+					{Content: "proposed", ID: "status-id"},
+					{Content: "", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 				},
 			},
@@ -248,6 +252,10 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "medium", ID: "caseimportance"},
 					{Content: "automated", ID: "caseautomation"},
 					{Content: "functional", ID: "testtype"},
+					{Content: "-", ID: "subtype1"},
+					{Content: "-", ID: "subtype2"},
+					{Content: "proposed", ID: "status-id"},
+					{Content: "", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 				},
 			},
@@ -255,6 +263,10 @@ var _ = Describe("Test Case Generator", func() {
 				CustomFields: []polarion_xml.TestCaseCustomField{
 					{Content: "automated", ID: "caseautomation"},
 					{Content: "functional", ID: "testtype"},
+					{Content: "-", ID: "subtype1"},
+					{Content: "-", ID: "subtype2"},
+					{Content: "proposed", ID: "status-id"},
+					{Content: "", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 					{Content: "critical", ID: "caseimportance"},
 					{Content: "negative", ID: "caseposneg"},
@@ -264,6 +276,10 @@ var _ = Describe("Test Case Generator", func() {
 				CustomFields: []polarion_xml.TestCaseCustomField{
 					{Content: "automated", ID: "caseautomation"},
 					{Content: "functional", ID: "testtype"},
+					{Content: "-", ID: "subtype1"},
+					{Content: "-", ID: "subtype2"},
+					{Content: "proposed", ID: "status-id"},
+					{Content: "", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 					{Content: "low", ID: "caseimportance"},
 				},


### PR DESCRIPTION
While the import itself was working, there are some required fields,
which without them we cannot approve the TCs in Polarion

added: subtype1 & subtype2, automation script, status-id (proposed, we may want to change it to approved in the future)