### PR TITLE
Test case status-id removed

### DIFF
--- a/pkg/polarion-generator/test_cases_generator.go
+++ b/pkg/polarion-generator/test_cases_generator.go
@@ -221,7 +221,6 @@ func parseTable(testcases *polarion_xml.TestCases, block *ginkgoBlock, exprs []a
 		addCustomField(&testCase.TestCaseCustomFields, "testtype", "functional")
 		addCustomField(&testCase.TestCaseCustomFields, "subtype1", "-")
 		addCustomField(&testCase.TestCaseCustomFields, "subtype2", "-")
-		addCustomField(&testCase.TestCaseCustomFields, "status-id", "proposed")
 		addCustomField(&testCase.TestCaseCustomFields, "automation_script", filename)
 		addCustomField(&testCase.TestCaseCustomFields, "upstream", "yes")
 		testcases.TestCases = append(testcases.TestCases, *testCase)
@@ -353,7 +352,6 @@ func FillPolarionTestCases(f *ast.File, testCases *polarion_xml.TestCases, comme
 				addCustomField(&customFields, "testtype", "functional")
 				addCustomField(&customFields, "subtype1", "-")
 				addCustomField(&customFields, "subtype2", "-")
-				addCustomField(&customFields, "status-id", "proposed")
 				addCustomField(&customFields, "automation_script", filename)
 				addCustomField(&customFields, "upstream", "yes")
 				testCase := polarion_xml.TestCase{

--- a/pkg/polarion-generator/test_cases_generator_test.go
+++ b/pkg/polarion-generator/test_cases_generator_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Test Case Generator", func() {
 		cmap := ast.NewCommentMap(fset, f, f.Comments)
 
 		testCases = &polarion_xml.TestCases{}
-		FillPolarionTestCases(f, testCases, &cmap, "")
+		FillPolarionTestCases(f, testCases, &cmap, "myscript.go")
 
 		Expect(len(testCases.TestCases)).To(Equal(4))
 	})
@@ -241,8 +241,7 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "functional", ID: "testtype"},
 					{Content: "-", ID: "subtype1"},
 					{Content: "-", ID: "subtype2"},
-					{Content: "proposed", ID: "status-id"},
-					{Content: "", ID: "automation_script"},
+					{Content: "myscript.go", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 				},
 			},
@@ -254,8 +253,7 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "functional", ID: "testtype"},
 					{Content: "-", ID: "subtype1"},
 					{Content: "-", ID: "subtype2"},
-					{Content: "proposed", ID: "status-id"},
-					{Content: "", ID: "automation_script"},
+					{Content: "myscript.go", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 				},
 			},
@@ -265,8 +263,7 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "functional", ID: "testtype"},
 					{Content: "-", ID: "subtype1"},
 					{Content: "-", ID: "subtype2"},
-					{Content: "proposed", ID: "status-id"},
-					{Content: "", ID: "automation_script"},
+					{Content: "myscript.go", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 					{Content: "critical", ID: "caseimportance"},
 					{Content: "negative", ID: "caseposneg"},
@@ -278,8 +275,7 @@ var _ = Describe("Test Case Generator", func() {
 					{Content: "functional", ID: "testtype"},
 					{Content: "-", ID: "subtype1"},
 					{Content: "-", ID: "subtype2"},
-					{Content: "proposed", ID: "status-id"},
-					{Content: "", ID: "automation_script"},
+					{Content: "myscript.go", ID: "automation_script"},
 					{Content: "yes", ID: "upstream"},
 					{Content: "low", ID: "caseimportance"},
 				},


### PR DESCRIPTION
there are 2 problems with this field:
1. if the test case is already approved, it results with import error
2. test case cannot be set to 'proposed' without importance & level fields (most, if not all kubevirt tests, dont have these fields set today)

also added auto script name to the testing for a more meaningful verification