### PR TITLE
Support different (optional) test ID prefix

### DIFF
--- a/pkg/ginkgo-reporters/README.md
+++ b/pkg/ginkgo-reporters/README.md
@@ -14,6 +14,7 @@ This reporter fills in the xunit file the needed fields in order to upload it in
 #### Optional parameters:
 - --polarion-report-file the output file will be generated under working directory, the default is polarion_results.xml
 - --test-suite-params="OS=EL8 Storage=NFS Arch=x86" will be set under 'properties' and the values will get concatenated to the test run name 
+- --test-id-prefix="PREFIX" will set "PREFIX" for each test ID in test properties, if this parameter is not passed, the project ID parameter is set to be that prefix by default
 
 ### Usage
 

--- a/pkg/ginkgo-reporters/polarion_reporter_test.go
+++ b/pkg/ginkgo-reporters/polarion_reporter_test.go
@@ -150,7 +150,7 @@ var _ = Describe("ginkgo_reporters", func() {
 					Property: []PolarionProperty{
 						{
 							Name:  "polarion-testcase-id",
-							Value: "QE-123",
+							Value: "PREFIX-123",
 						},
 					},
 				},
@@ -170,7 +170,7 @@ var _ = Describe("ginkgo_reporters", func() {
 					Property: []PolarionProperty{
 						{
 							Name:  "polarion-testcase-id",
-							Value: "QE-789",
+							Value: "PREFIX-789",
 						},
 					},
 				},
@@ -183,6 +183,7 @@ var _ = Describe("ginkgo_reporters", func() {
 			Filename:  "polarion.xml",
 			ProjectId: "QE",
 			PlannedIn: "QE_1.0",
+			TestIDPrefix: "PREFIX",
 		}
 
 		It("Should info reporter test cases did complete", func() {


### PR DESCRIPTION
The assumption so far was that the project ID is also the prefix for test ID*,
but this assumption is incorrect, so adding an option to pass a different prefix if needed

* if you pass polarion project QE1, every test case (if uploaded by ID) is assumed to be of struct QE1-testID

Signed-off-by: Nelly Credi <ncredi@redhat.com>