### PR TITLE
Fix bug in test run title check

### DIFF
--- a/pkg/ginkgo-reporters/polarion_reporter.go
+++ b/pkg/ginkgo-reporters/polarion_reporter.go
@@ -129,7 +129,7 @@ func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigT
 		reporter.Suite.Properties.Property = addProperty(
 			reporter.Suite.Properties.Property, "polarion-testrun-template-id", reporter.TestRunTemplate)
 	}
-	if reporter.TestRunTemplate != "" {
+	if reporter.TestRunTitle != "" {
 		reporter.Suite.Properties.Property = addProperty(
 			reporter.Suite.Properties.Property, "polarion-testrun-title", reporter.TestRunTitle)
 	}


### PR DESCRIPTION
was using the wrong parameter to check if test run title should be set in the test suite properties

Signed-off-by: Nelly Credi <ncredi@redhat.com>