### PR TITLE
Comma polarion reporter custom vars

### DIFF
--- a/pkg/ginkgo-reporters/polarion_reporter.go
+++ b/pkg/ginkgo-reporters/polarion_reporter.go
@@ -103,7 +103,7 @@ func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigT
 	}
 
 	valuesString := ""
-	suiteParams := strings.Split(reporter.TestSuiteParams, " ")
+	suiteParams := splitAny(reporter.TestSuiteParams, " ,")
 	for _, s := range suiteParams {
 		keyValue := strings.Split(s, "=")
 		if len(keyValue) > 1 {
@@ -258,4 +258,11 @@ func addProperty(properties []PolarionProperty, key string, value string) []Pola
 			Value: value,
 	})
 	return properties
+}
+
+func splitAny(s string, seps string) []string {
+	splitter := func(r rune) bool {
+		return strings.ContainsRune(seps, r)
+	}
+	return strings.FieldsFunc(s, splitter)
 }

--- a/pkg/ginkgo-reporters/polarion_reporter_test.go
+++ b/pkg/ginkgo-reporters/polarion_reporter_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ginkgo_reporters", func() {
 			ProjectId:       "QE",
 			PlannedIn:       "QE_1.0",
 			LookupMethod:    "id",
-			TestSuiteParams: "OS=EL7 SC=NFS",
+			TestSuiteParams: "OS=EL7 SC=NFS,ENV_TIER=TIER1",
 			TestRunTemplate: "QE_Regression_template",
 			TestRunTitle:    "My run title",
 		}
@@ -71,6 +71,10 @@ var _ = Describe("ginkgo_reporters", func() {
 					Value: "NFS",
 				},
 				{
+					Name:  "polarion-custom-ENV_TIER",
+					Value: "TIER1",
+				},
+				{
 					Name:  "polarion-project-id",
 					Value: "QE",
 				},
@@ -84,7 +88,7 @@ var _ = Describe("ginkgo_reporters", func() {
 				},
 				{
 					Name:  "polarion-testrun-id",
-					Value: "QE_1.0_EL7_NFS",
+					Value: "QE_1.0_EL7_NFS_TIER1",
 				},
 				{
 					Name:  "polarion-custom-isautomated",


### PR DESCRIPTION
At some projects like kubernetes-nmstate using spaces is no good sime it's used by the operator-sdk cli to separate go test flags, this PR add comma as a separator so we can use it instead of spaces.

Comment for reviewers:
This PR is in top of another that migrate qe-tools to go modules.